### PR TITLE
ensembl-funcgen now has a cpanfile, use it

### DIFF
--- a/roles/ensembl/tasks/main.yml
+++ b/roles/ensembl/tasks/main.yml
@@ -63,5 +63,6 @@
   with_items:
        - ensembl
        - ensembl-compara
+       - ensembl-funcgen
        - ensembl-variation
   when: repos_exist


### PR DESCRIPTION
This is so that the Role::Tiny module gets installed. See ENSCORESW-2717.