### PR TITLE
Improve support for deployment on localhost

### DIFF
--- a/vars/main_local.yml
+++ b/vars/main_local.yml
@@ -1,5 +1,5 @@
-ensembl_user: $USER
-ensembl_group: ensembl
+ensembl_user: ${USER}
+ensembl_group: users
 ensembl_install_dir: "/home/{{ ensembl_user }}/src"
 logdir: "{{ ensembl_install_dir }}/log"
 homedir: "/home/{{ ensembl_user }}"


### PR DESCRIPTION
1.Change $USER to ${USER} in main_local.yml
Having no curly brances around the variable name makes in this case no
difference to Ansible itself but causes problems when Ansible attempts
to compile variation C tools - make treats $USER as $(U)SER and with $U
not having been set, ends up looking for htslib files in /home/SER/... .

See-also: https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-2807