### PR TITLE
Fix for ensure catalyst is not confused by unusual filesystems.

### DIFF
--- a/rest_ebi.yml
+++ b/rest_ebi.yml
@@ -17,6 +17,7 @@
     vcf_config_json: vcf_config_ebi.json.j2
     ga_vcf_config_json: ga_vcf_config_ebi.json.j2
     compara_halxs_makefile: Makefile-Linuxbrew.PL
+    fix_catalyst_root_dir: true
 
   environment:
     HTSLIB_DIR: "{{ ensembl_install_dir}}/htslib"

--- a/roles/rest_config/tasks/main.yml
+++ b/roles/rest_config/tasks/main.yml
@@ -129,3 +129,9 @@
     - { src: "{{ rest_private_dir }}/static/wrapper.tt", dest: "{{ ensembl_install_dir }}/ensembl-rest/root/wrapper.tt" }
     - { src: "{{ rest_private_dir }}/static/10-bootstrap.css", dest: "{{ ensembl_install_dir }}/ensembl-rest/root/static/css/10-bootstrap.css" }
   when: human_assembly == "GRCh37"
+
+- name: Fix ROOT directory for unusual filesystems
+  lineinfile:
+    dest="{{ PERL_RC | default('~/.bashrc') }}"
+    line="export ENSEMBL_REST_HOME=$(cd \"$(dirname \"${BASH_SOURCE[0]}\")\" >/dev/null 2>&1 && pwd)/ensembl-rest"
+  when: fix_catalyst_root_dir|bool


### PR DESCRIPTION
The Catalyst Root is a path used at various points inside catalyst for converting relative paths to absolute paths. Ensembl REST uses these methods in a few places, including the documentation controller.

If the Catalyst Root is not specified, a default value is used which is certainly a valid path to the checkout at some point during startup. However, some filesystems require us to take more control of the value of the root as the way a path is accessed has an impact as to its continuing validity.

An example is that a file might be correctly accessed through a symlink, the destination of which change unpredictably during execution (due to backups etc). Resolving the symlink path to the non-symlinked path works until the symlink moves and the underlying path deleted. This happens at EBI, for example.

Catalyst provides a means of explicitly specifying the Catalyst Root through environment variables, which we use here by adding a line to activate_ensembl. This line uses the path by which activate_ensembl was called as the basis of the Catalyst Root. The line only activates on setting a variable, as fixes of this kind tend to have unintended consequences on existing, working setups depending on the details of their file system structure.

I use shell-specific variables to determine the current path as no generic POSIX-sh solution exists with the same semantics. This is another good reason to restrict its use by an ansible variable. A shell-guru may well be able to find the right magic and update the line, but I've spent considerable time trying out many solutions.

This PR has been tested with the variable present and true, present and false, and absent, and the results checked in activate_ensembl. The added line matches exactly the activate_ensembl currently in live production, where it is working and addresses the previously seen live REST bug.