### PR TITLE
ENSCORESW-3149: Bugfix for ensembl VM

### DIFF
--- a/roles/desktop/tasks/main.yml
+++ b/roles/desktop/tasks/main.yml
@@ -121,7 +121,7 @@
   with_items:
     - { src: "{{role_path}}/files/lock_disable.sh", dest: "/home/lock_disable.sh" }
     - { src: "{{role_path}}/files/lock_disable.sh.desktop", dest: "/etc/xdg/autostart/lock_disable.sh.desktop" }
-    - { src: "{{role_path}}/files/google-chrome.desktop", dest: "{{ homedir }}/Desktop/google-chrome.desktop" }
+#    - { src: "{{role_path}}/files/google-chrome.desktop", dest: "{{ homedir }}/Desktop/google-chrome.desktop" }
     - { src: "{{role_path}}/files/VEP.desktop", dest: "{{ homedir }}/Desktop/VEP.desktop" }
   when: desktop_dir_created
 

--- a/roles/ensembl/tasks/main.yml
+++ b/roles/ensembl/tasks/main.yml
@@ -82,5 +82,5 @@
        - ensembl
        - ensembl-compara
        - ensembl-funcgen
-#       - ensembl-variation
+       - ensembl-variation
   when: repos_exist

--- a/roles/ensembl/tasks/main.yml
+++ b/roles/ensembl/tasks/main.yml
@@ -83,4 +83,4 @@
        - ensembl-compara
        - ensembl-funcgen
        - ensembl-variation
-  when: repos_exist
+  when: paths_set

--- a/roles/ensembl/tasks/main.yml
+++ b/roles/ensembl/tasks/main.yml
@@ -77,7 +77,7 @@
 - name: Install Ensembl repo cpan dependencies
   shell: ". {{ PERL_RC | default('~/.bashrc') }} && cpanm -v --installdeps --with-recommends --notest --cpanfile={{ ensembl_install_dir }}/{{ item }}/cpanfile ."
   args:
-    chdir="{{ ensembl_install_dir }}/{{ item }}"
+    chdir: "{{ ensembl_install_dir }}/{{ item }}"
   with_items:
        - ensembl
        - ensembl-compara

--- a/roles/ensembl/tasks/main.yml
+++ b/roles/ensembl/tasks/main.yml
@@ -31,15 +31,6 @@
   when: ensembl_dir_exists
   register: repos_exist
 
-- name: Configure ensembl environment
-  lineinfile: dest="{{ PERL_RC | default('~/.bashrc') }}" line="{{ item }}" create=yes
-  with_items:
-       - export HTSLIB_DIR={{ ensembl_install_dir}}/htslib
-       - export PERL5LIB={{ ensembl_install_dir }}/ensembl-metadata/modules:{{ ensembl_install_dir }}/ensembl-taxonomy/modules:{{ ensembl_install_dir }}/ensembl-compara/modules:{{ ensembl_install_dir }}/ensembl-funcgen/modules:{{ ensembl_install_dir }}/ensembl-hdf5/modules:{{ ensembl_install_dir }}/ensembl-io/modules:{{ ensembl_install_dir }}/ensembl/modules:{{ ensembl_install_dir }}/ensembl-test/modules:{{ ensembl_install_dir }}/ensembl-variation/modules:{{ ensembl_install_dir }}/ensembl-vep/modules:{{ ensembl_install_dir }}/ensembl-rest/lib:{{ ensembl_install_dir }}/ensembl-git-tools/lib:{{ ensembl_install_dir }}/ensembl-hdf5/modules:{{ ensembl_install_dir }}/bioperl-live:$PERL5LIB
-       - export PATH={{ ensembl_install_dir }}/ensembl-git-tools/bin:{{ ensembl_install_dir }}/ensembl-git-tools/advanced_bin:{{ ensembl_install_dir }}/ensembl-variation/C_code:{{ ensembl_install_dir }}/htslib:$PATH
-  when: repos_exist
-  register: paths_set
-
 - name: Build HTSLIB
   shell: "make"
   args:
@@ -48,12 +39,37 @@
   when: repos_exist
   register: htslib_built
 
+- name: Get Kent
+  script: "{{ ensembl_install_dir }}/ensembl-variation/travisci/get_dependencies.sh"
+  args:
+    chdir: "{{ ensembl_install_dir }}"
+  when: repos_exist
+  register: get_kent
+
+- name: Build Kent
+  script: "{{ ensembl_install_dir }}/ensembl-variation/travisci/build_c.sh"
+  args:
+    chdir: "{{ ensembl_install_dir }}"
+  when: get_kent
+  register: kent_built
+
 - name: Build variation C progs
   shell: "make && make install"
   args:
     chdir: "{{ ensembl_install_dir }}/ensembl-variation/C_code"
     creates: ../calc_genotypes
-  when: htslib_built and paths_set
+  when: htslib_built and kent_built
+
+- name: Configure ensembl environment
+  lineinfile: dest="{{ PERL_RC | default('~/.bashrc') }}" line="{{ item }}" create=yes
+  with_items:
+       - export HTSLIB_DIR={{ ensembl_install_dir}}/htslib
+       - export PERL5LIB={{ ensembl_install_dir }}/ensembl-metadata/modules:{{ ensembl_install_dir }}/ensembl-taxonomy/modules:{{ ensembl_install_dir }}/ensembl-compara/modules:{{ ensembl_install_dir }}/ensembl-funcgen/modules:{{ ensembl_install_dir }}/ensembl-hdf5/modules:{{ ensembl_install_dir }}/ensembl-io/modules:{{ ensembl_install_dir }}/ensembl/modules:{{ ensembl_install_dir }}/ensembl-test/modules:{{ ensembl_install_dir }}/ensembl-variation/modules:{{ ensembl_install_dir }}/ensembl-vep/modules:{{ ensembl_install_dir }}/ensembl-rest/lib:{{ ensembl_install_dir }}/ensembl-git-tools/lib:{{ ensembl_install_dir }}/ensembl-hdf5/modules:{{ ensembl_install_dir }}/bioperl-live:$PERL5LIB
+       - export PATH={{ ensembl_install_dir }}/ensembl-git-tools/bin:{{ ensembl_install_dir }}/ensembl-git-tools/advanced_bin:{{ ensembl_install_dir }}/ensembl-variation/C_code:{{ ensembl_install_dir }}/htslib:$PATH
+       - export KENT_SRC={{ ensembl_install_dir }}/kent-335_base/src
+       - export MACHTYPE=$(uname -m)
+  when: repos_exist and kent_built
+  register: paths_set
 
 #  command: "sudo -iu {{ ensembl_user }} cpanm -v --installdeps --with-recommends --notest --cpanfile={{ ensembl_install_dir }}/{{ item }}/cpanfile ."
 #  command: "source $SHARE_PATH/.bashrc_linuxbrew && source $SHARE_PATH/.bashrc_ensembl && cpanm -v --installdeps --with-recommends --notest --cpanfile={{ ensembl_install_dir }}/{{ item }}/cpanfile ."

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -20,6 +20,9 @@
        - python-pip
        - virtualenv
        - libssl-dev
+       - libpng-dev
+       - uuid-dev
+       - e2fsprogs
   when: ansible_os_family == 'Debian'
 
 # Not yet tested on a RH based system

--- a/vm/ensembl.json
+++ b/vm/ensembl.json
@@ -7,7 +7,7 @@
   "disk_size": "12000",
   "iso_checksum": "16afb1375372c57471ea5e29803a89a5a6bd1f6aabea2e5e34ac1ab7eb9786ac",
   "iso_checksum_type": "sha256",
-  "iso_name": "ubuntu-16.04.5-server-amd64.iso",
+  "iso_name": "ubuntu-16.04.6-server-amd64.iso",
   "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.6-server-amd64.iso",
   "memory": "1024",
   "preseed": "preseed.cfg",

--- a/vm/ensembl.sh
+++ b/vm/ensembl.sh
@@ -23,7 +23,7 @@ apt-get install -y build-essential libssl-dev libffi-dev python-pip git
 pip install ansible
 
 # Clone the repo for doing the install
-git clone -b vm_bugfix https://github.com/Ensembl/ensembl-rest-deploy.git
+git clone https://github.com/Ensembl/ensembl-rest-deploy.git
 
 # Clone the perlbrew repo for the install
 cd ensembl-rest-deploy

--- a/vm/ensembl.sh
+++ b/vm/ensembl.sh
@@ -23,7 +23,7 @@ apt-get install -y build-essential libssl-dev libffi-dev python-pip git
 pip install ansible
 
 # Clone the repo for doing the install
-git clone https://github.com/Ensembl/ensembl-rest-deploy.git
+git clone -b vm_bugfix https://github.com/Ensembl/ensembl-rest-deploy.git
 
 # Clone the perlbrew repo for the install
 cd ensembl-rest-deploy


### PR DESCRIPTION
The building of Ensembl VM got broken due to an added dependency in the ensembl-variation cpan file.
This update will fix the issue.