### PR TITLE
Bugfix/loftee [release/99]

### DIFF
--- a/roles/rest/tasks/main.yml
+++ b/roles/rest/tasks/main.yml
@@ -30,10 +30,10 @@
        - { repo: 'https://github.com/Ensembl/loftee.git', dir: loftee, version: "{{ loftee_version }}" }
   when: rest_dir_exists
 
-- name: Add Loftee to the path
+- name: Add Loftee to the PERL5LIB
   lineinfile:
     dest="{{ PERL_RC | default('~/.bashrc') }}"
-    line="export PATH={{ ensembl_install_dir }}/loftee:$PATH"
+    line="export PERL5LIB={{ ensembl_install_dir }}/loftee:$PERL5LIB"
   when: rest_dir_exists
 
 - name: Set LD_LIBRARY_PATH for local packages

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,5 +6,3 @@ homedir: "/home/{{ ensembl_user }}"
 
 hdf5_version: 1.8.18
 validate_rest: true
-
-loftee_version: grch38


### PR DESCRIPTION
This PR try to
1. Adding Loftee checkout to the PERL5LIB, it does not need to be in PATH
2. Remove loftee_version variable from vars/main.yml as loftee uses different branch for www and grch37.
The variable should stay in appropriate conf dirs as below
https://github.com/Ensembl/ensembl-rest_private/commit/202d4868efcbe1257e890450a699befe6f05b33a

The PR should be merged to release/99 and master