### PR TITLE
Feature/fallback

### DIFF
--- a/rest_ebi.yml
+++ b/rest_ebi.yml
@@ -31,4 +31,5 @@
     - { role: plenv, perl_version: 5.26.1, plenv_install_dir: "{{ ensembl_install_dir }}/.plenv" }
     - { role: rest, become: false }
     - { role: rest_config, become: false }
+    - { role: rest_config_fb, become: false, when: setup_fallback }
     - { role: rest_validate, become: false, when: validate_rest is defined and validate_rest|bool }

--- a/rest_ebi.yml
+++ b/rest_ebi.yml
@@ -31,5 +31,5 @@
     - { role: plenv, perl_version: 5.26.1, plenv_install_dir: "{{ ensembl_install_dir }}/.plenv" }
     - { role: rest, become: false }
     - { role: rest_config, become: false }
-    - { role: rest_config_fb, become: false, when: setup_fallback }
+    - { role: rest_config_fb, become: false, when: setup_fallback is defined and setup_fallback|bool }
     - { role: rest_validate, become: false, when: validate_rest is defined and validate_rest|bool }

--- a/roles/rest_config_fb/tasks/main.yml
+++ b/roles/rest_config_fb/tasks/main.yml
@@ -1,0 +1,16 @@
+# Role: rest_config for fallback
+
+- name: Loading variables of fallback it will override play vars_files
+  include_vars: "{{ rest_private_dir }}/conf/release_ebi_fallback.yml"
+
+- name: Create local copy of REST configs
+  local_action: template src="{{ item.src }}" dest="{{ item.dest }}" mode=0640
+  with_items:
+    - { src: "{{ rest_private_dir }}/conf/ensembl_rest.conf.j2", dest: "{{ rest_private_dir }}/conf/ensembl_rest_fallback.conf" }
+#  when: release_loaded
+
+- name: Deploying REST configs
+  template: src="{{ item.src }}" dest="{{ item.dest }}" mode=0640
+  with_items:
+    - { src: "{{ rest_private_dir }}/conf/ensembl_rest.conf.j2", dest: "{{ ensembl_install_dir }}/ensembl-rest/configurations/production/ensembl_rest_fallback.conf" }
+

--- a/roles/rest_config_fb/tasks/main.yml
+++ b/roles/rest_config_fb/tasks/main.yml
@@ -12,9 +12,11 @@
   template: src="{{ item.src }}" dest="{{ item.dest }}" mode=0640
   with_items:
     - { src: "{{ rest_private_dir }}/conf/ensembl_rest.conf.j2", dest: "{{ ensembl_install_dir }}/ensembl-rest/configurations/production/ensembl_rest_fallback.conf" }
+
 - name: Add Fallback config file detection
   blockinfile:
     dest: "{{ PERL_RC | default('~/.bashrc') }}"
+    marker: "# {mark} fallback config"
     content: |
       if [ "$REST_FALLBACK" = true ];then
         export ENSEMBL_REST_CONFIG={{ ensembl_install_dir }}/ensembl-rest/configurations/production/ensembl_rest_fallback.conf 

--- a/roles/rest_config_fb/tasks/main.yml
+++ b/roles/rest_config_fb/tasks/main.yml
@@ -12,4 +12,10 @@
   template: src="{{ item.src }}" dest="{{ item.dest }}" mode=0640
   with_items:
     - { src: "{{ rest_private_dir }}/conf/ensembl_rest.conf.j2", dest: "{{ ensembl_install_dir }}/ensembl-rest/configurations/production/ensembl_rest_fallback.conf" }
-
+- name: Add Fallback config file detection
+  blockinfile:
+    dest: "{{ PERL_RC | default('~/.bashrc') }}"
+    content: |
+      if [ "$REST_FALLBACK" = true ];then
+        export ENSEMBL_REST_CONFIG={{ ensembl_install_dir }}/ensembl-rest/configurations/production/ensembl_rest_fallback.conf 
+      fi

--- a/roles/rest_config_fb/tasks/main.yml
+++ b/roles/rest_config_fb/tasks/main.yml
@@ -1,15 +1,14 @@
 # Role: rest_config for fallback
 
-- name: Loading variables of fallback it will override play vars_files
+- name: Loading variables of fallback, it will override play vars_files
   include_vars: "{{ rest_private_dir }}/conf/release_ebi_fallback.yml"
 
-- name: Create local copy of REST configs
+- name: Create local copy of REST fallback configs
   local_action: template src="{{ item.src }}" dest="{{ item.dest }}" mode=0640
   with_items:
     - { src: "{{ rest_private_dir }}/conf/ensembl_rest.conf.j2", dest: "{{ rest_private_dir }}/conf/ensembl_rest_fallback.conf" }
-#  when: release_loaded
 
-- name: Deploying REST configs
+- name: Deploying REST fallback configs
   template: src="{{ item.src }}" dest="{{ item.dest }}" mode=0640
   with_items:
     - { src: "{{ rest_private_dir }}/conf/ensembl_rest.conf.j2", dest: "{{ ensembl_install_dir }}/ensembl-rest/configurations/production/ensembl_rest_fallback.conf" }


### PR DESCRIPTION
This PR adds a new role: rest_config_fb
When running the rest_ebi playbook with `-e setup_fallback=true`, this role will be invoked.
It creates a new REST config file and set ENSEMBL_REST_CONFIG  to use the right config file

Tested on my dev machine.
Expected output:
- New file ensembl_rest_fallback.conf
- New lines inside activate_ensembl