### PR TITLE
Bump perl version to match compara's

### DIFF
--- a/rest_ebi.yml
+++ b/rest_ebi.yml
@@ -29,7 +29,7 @@
 
   roles:
     - { role: ebi_brew, become: false }
-    - { role: plenv, perl_version: 5.26.1, plenv_install_dir: "{{ ensembl_install_dir }}/.plenv" }
+    - { role: plenv, perl_version: 5.26.2, plenv_install_dir: "{{ ensembl_install_dir }}/.plenv" }
     - { role: rest, become: false }
     - { role: rest_config, become: false }
     - { role: rest_config_fb, become: false, when: setup_fallback is defined and setup_fallback|bool }


### PR DESCRIPTION
The perl version required by the REST deployment has been bumped to 5.26.2, but this repo was still configured to use 5.26.1, which causes the deployment to fail. This PR updates the YAML that tells plenv which version of perl to install.